### PR TITLE
use windows 2022 in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
             win64,
             mingw32,
             mingw64,
-            windows-2019,
+            windows-2022,
           ]
         cargo_flags: ['', '--release', '--features parallel']
         include:


### PR DESCRIPTION
I received this email from GitHub:
![image](https://github.com/user-attachments/assets/a6378bb8-f0a2-4361-b4f9-b91929bede13)
